### PR TITLE
Remove obsolete aufs from Tails

### DIFF
--- a/grub2/inc-tails.cfg
+++ b/grub2/inc-tails.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/tails/tails-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/live/vmlinuz boot=live findiso=${isofile} config apparmor=1 security=apparmor nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 splash noautologin module=Tails kaslr slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 union=aufs quiet
+    linux (loop)/live/vmlinuz boot=live findiso=${isofile} config apparmor=1 security=apparmor nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 splash noautologin module=Tails kaslr slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 quiet
     initrd (loop)/live/initrd.img
   }
 done


### PR DESCRIPTION
Removed `union=aufs`, because that was causing an error message "aufs not available" during startup. 
As far as I can tell aufs has been removed here: https://gitlab.tails.boum.org/tails/tails/-/issues/8415