### PR TITLE
Detect alternative Fedora ISOs and minimal Manjaro

### DIFF
--- a/grub2/inc-fedora.cfg
+++ b/grub2/inc-fedora.cfg
@@ -4,9 +4,10 @@ for isofile in $isopath/fedora/Fedora-*.iso; do
   regexp \
     --set 1:isoname \
     --set 2:variant \
-    --set 3:arch \
-    --set 4:version \
-    "^${isopath}/fedora/(Fedora-([^-]+)-Live-([^-]+)-([^-]+)-[^-]+\.iso)\$" "${isofile}"
+    --set 3:isovariant \
+    --set 4:arch \
+    --set 5:version \
+    "^${isopath}/fedora/(Fedora-([^-]+)-([^-]+)-([^-]+)-([^-]+)-[^-]+\.iso)\$" "${isofile}"
   menuentry "Fedora ${version} ${arch} ${variant}" "${isofile}" "${isoname}" --class fedora {
     set isofile=$2
     set isoname=$3

--- a/grub2/inc-manjaro.cfg
+++ b/grub2/inc-manjaro.cfg
@@ -5,9 +5,9 @@ for isofile in $isopath/manjaro/manjaro-*.iso; do
     --set 1:isoname \
     --set 2:variant \
     --set 3:version \
-    --set 4:reldate \
-    --set 5:kernel \
-    "^${isopath}/manjaro/(manjaro-([^-]+)-([^-]+)-([^-]+)-([^-]+)\.iso)\$" "${isofile}"
+    --set 5:reldate \
+    --set 6:kernel \
+    "^${isopath}/manjaro/(manjaro-([^-]+)-([^-]+(-minimal)?)-([^-]+)-([^-]+)\.iso)\$" "${isofile}"
   menuentry "Manjaro ${variant} ${version} ${reldate} ${kernel}" "${isofile}" "${isoname}" --class manjaro {
     set isofile=$2
     set isoname=$3


### PR DESCRIPTION
Fedora Server ISOs use `dvd` instead of `Live` for example.