### PR TITLE
Arch Linux 32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The supported `boot/iso/` sub-directories (in alphabetical order) are :
     antergos
     antix
     arch
+    arch32
     bodhi
     centos
     clonezilla

--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -53,6 +53,15 @@ for isofile in ${isopath}/arch/archlinux-*.iso; do
   fi
 done
 
+for isofile in ${isopath}/arch32/archlinux32-*.iso; do
+  if [ -e "$isofile" ]; then
+    menuentry "Arch Linux 32 >" --class arch {
+      configfile "${prefix}/inc-arch32.cfg"
+    }
+    break
+  fi
+done
+
 for isofile in ${isopath}/bodhi/bodhi-*.iso; do
   if [ -e "$isofile" ]; then
     menuentry "Bodhi Linux >" --class bodhi {

--- a/grub2/inc-arch32.cfg
+++ b/grub2/inc-arch32.cfg
@@ -1,0 +1,17 @@
+# Arch 32
+for isofile in $isopath/arch32/archlinux32-*.iso; do
+  if [ ! -e "$isofile" ]; then break; fi
+  regexp \
+    --set 1:isoname \
+    --set 2:version \
+    --set 3:arch \
+    "^${isopath}/arch32/(archlinux32-([^-]+)-([^-]+)\.iso)\$" "${isofile}"
+  menuentry "Arch Linux 32 ${version} ${arch}" "${isofile}" "${isoname}" --class arch {
+    set isofile=$2
+    set isoname=$3
+    echo "Using ${isoname}..."
+    loopback loop $isofile
+    linux (loop)/arch/boot/i686/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
+    initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/i686/initramfs-linux.img
+  }
+done


### PR DESCRIPTION
Arch Linux 32 has a different ISO structure and won't work with
the normal Arch configuration file, created a new menu entry to
handle it.